### PR TITLE
Add script to fetch Redfish tests and build directory tree for test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,60 @@ optional arguments:
                         IfSendingCredentials or IfLoginOrAuthenticatedApi
 ```
 
+## Quick Start (install and run)
+
+To get the Redfish Test Framework installed and ready to run, follow these steps.
+
+* Download the framework zip file from: https://github.com/DMTF/Redfish-Test-Framework/archive/master.zip
+* Unzip the file to the location of your choice.
+* Change directory into the top level directory of the unziped file:
+
+```
+cd Redfish-Test-Framework-master
+```
+
+* Run the `build_test_tree.py` script:
+
+```
+python3 build_test_tree.py
+```
+
+At this point you will have a test tree of tests to run. In the current directory there is a top-level config file called `framework_conf.json`. It will look something like this:
+
+```
+{
+  "target_system": "127.0.0.1:8000",
+  "https": "Always",
+  "username": "someuser",
+  "password": "xxxxxxxx",
+  "interpreter": "python3",
+  "custom_variables": {
+    "system_id": "sys1",
+    "metadata_url": "https://127.0.0.1:8000/redfish/v1/$metadata",
+    "nochkcert": "--nochkcert",
+    "secure": "-S"
+  }
+}
+```
+
+* Using you favorite text editor, edit the following entries in the file:
+    * `target_system` - edit the value to be the IP address or hostname of your target system with optional :port
+    * `username` - edit the value to specify the user name to use for authentication to the target system
+    * `password` - specify the password for the user name to use for authentication
+    * `interpreter` - specify the name of the python 3 interpreter to use to run the tests
+    * `system_id` - specify the identifier of a system in the Systems collection of the target (this is used to perform a reset operation on the specified system in the Redfish-Usecase-Checkers power_control test)
+    * `metadata_url` - edit the `127.0.0.1:8000` portion of the url to match the target_system value specified above (this url is used by the Redfish-Reference-Checker test)
+
+* You can now run the tests via the test framework tool:
+
+```
+python3 test_framework.py
+```
+
+For more information on customizing the variables in the config files, adding new tests to the framework and reviewing the test output, see the sections below.
+
+
+
 ## Test Setup
 
 In order to run  a set of tests, some setup work is needed to organize the tests into the directory structure expected by the framework. Choose a top-level directory in which to setup the tests. In this top-level directory will be 2 files, the test framework script itself (`test_framework.py`), and the top-level config file (`framework_conf.json`). Then create a subdirectory for each suite of tests to be run. Example suite-level subdirectories would be `Redfish-Service-Validator` and `Redfish-Usecase-Checkers`. The names of these subdirectories are not important (the test framework discovers tests within this described directory hierarchy). But using descriptive names like the examples given will make using the framework and reading the output reports easier.

--- a/build_test_tree.py
+++ b/build_test_tree.py
@@ -11,11 +11,9 @@ import sys
 
 
 def download_zip(subdir, zip_url):
-    print('Extracting {} into {}'.format(zip_url, subdir))
+    print('Extracting {} into {}'.format(zip_url, subdir if subdir is not None else '$PWD'))
 
     # Create subdirectory if specified
-    # TODO: Come up with better subdirectory model
-    '''
     if subdir is not None:
         try:
             subdir = os.path.abspath(subdir)
@@ -26,7 +24,6 @@ def download_zip(subdir, zip_url):
             exit(1)
     else:
         subdir = os.getcwd()
-    '''
 
     # Fetch zip
     r = None
@@ -43,8 +40,7 @@ def download_zip(subdir, zip_url):
     # Extract zip
     try:
         z = zipfile.ZipFile(io.BytesIO(r.content), mode='r')
-        # z.extractall(path=subdir)
-        z.extractall()
+        z.extractall(path=subdir)
     except Exception as e:
         print('Unable to extract zip from {}. Exception is "{}"'.format(zip_url, e), file=sys.stderr)
         exit(1)
@@ -69,10 +65,10 @@ def main():
             exit(1)
 
     download_list = [
-        ['root_schema_validation', 'https://github.com/DMTF/Redfish-Service-Validator/archive/master.zip'],
-        ['root_metadata', 'https://github.com/DMTF/Redfish-Reference-Checker/archive/master.zip'],
-        ['default_mockup', 'https://github.com/DMTF/Redfish-Mockup-Creator/archive/master.zip'],
-        ['basic_profile', 'https://github.com/DMTF/Redfish-Interop-Validator/archive/master.zip'],
+        ['Schema-Validation', 'https://github.com/DMTF/Redfish-Service-Validator/archive/master.zip'],
+        ['Other-Tests', 'https://github.com/DMTF/Redfish-Reference-Checker/archive/master.zip'],
+        ['Other-Tests', 'https://github.com/DMTF/Redfish-Mockup-Creator/archive/master.zip'],
+        ['Profile-Validation', 'https://github.com/DMTF/Redfish-Interop-Validator/archive/master.zip'],
         [None, 'https://github.com/DMTF/Redfish-Usecase-Checkers/archive/master.zip']
     ]
 

--- a/build_test_tree.py
+++ b/build_test_tree.py
@@ -1,0 +1,84 @@
+# Copyright Notice:
+# Copyright 2017 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Test-Framework/LICENSE.md
+
+import argparse
+import io
+import os
+import requests
+import zipfile
+import sys
+
+
+def download_zip(subdir, zip_url):
+    print('Extracting {} into {}'.format(zip_url, subdir))
+
+    # Create subdirectory if specified
+    # TODO: Come up with better subdirectory model
+    '''
+    if subdir is not None:
+        try:
+            subdir = os.path.abspath(subdir)
+            if not os.path.isdir(subdir):
+                os.mkdir(subdir)
+        except OSError as e:
+            print("Error creating target subdirectory {}, error: {}".format(subdir, e), file=sys.stderr)
+            exit(1)
+    else:
+        subdir = os.getcwd()
+    '''
+
+    # Fetch zip
+    r = None
+    try:
+        r = requests.get(zip_url, stream=True)
+        if r.status_code != requests.codes.ok:
+            print("Unable to retrieve zip at {}. Status = {}, response = {}".format(zip_url, r.status_code, r.text),
+                  file=sys.stderr)
+            exit(1)
+    except Exception as e:
+        print('Unable to retrieve zip at {}. Exception is "{}"'.format(zip_url, e), file=sys.stderr)
+        exit(1)
+
+    # Extract zip
+    try:
+        z = zipfile.ZipFile(io.BytesIO(r.content), mode='r')
+        # z.extractall(path=subdir)
+        z.extractall()
+    except Exception as e:
+        print('Unable to extract zip from {}. Exception is "{}"'.format(zip_url, e), file=sys.stderr)
+        exit(1)
+
+
+def main():
+    arg_parser = argparse.ArgumentParser(description='Script to fetch Redfish tools and build test framework tree')
+    arg_parser.add_argument('-d', '--directory', help='target directory to populate with tests')
+    args = arg_parser.parse_args()
+
+    # TODO: Only support cwd as target?
+    if args.directory is None:
+        target_dir = os.getcwd()
+    else:
+        target_dir = args.directory
+        target_dir = os.path.abspath(target_dir)
+        try:
+            if not os.path.isdir(target_dir):
+                os.mkdir(target_dir)
+        except OSError as e:
+            print("Error creating target directory {}, error: {}".format(target_dir, e), file=sys.stderr)
+            exit(1)
+
+    download_list = [
+        ['root_schema_validation', 'https://github.com/DMTF/Redfish-Service-Validator/archive/master.zip'],
+        ['root_metadata', 'https://github.com/DMTF/Redfish-Reference-Checker/archive/master.zip'],
+        ['default_mockup', 'https://github.com/DMTF/Redfish-Mockup-Creator/archive/master.zip'],
+        ['basic_profile', 'https://github.com/DMTF/Redfish-Interop-Validator/archive/master.zip'],
+        [None, 'https://github.com/DMTF/Redfish-Usecase-Checkers/archive/master.zip']
+    ]
+
+    for subdir, zip_url in download_list:
+        download_zip(subdir, zip_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/build_test_tree.py
+++ b/build_test_tree.py
@@ -21,21 +21,20 @@ def download_zip(subdir, zip_url):
                 os.mkdir(subdir)
         except OSError as e:
             print("Error creating target subdirectory {}, error: {}".format(subdir, e), file=sys.stderr)
-            exit(1)
+            return
     else:
         subdir = os.getcwd()
 
     # Fetch zip
-    r = None
     try:
         r = requests.get(zip_url, stream=True)
         if r.status_code != requests.codes.ok:
             print("Unable to retrieve zip at {}. Status = {}, response = {}".format(zip_url, r.status_code, r.text),
                   file=sys.stderr)
-            exit(1)
+            return
     except Exception as e:
         print('Unable to retrieve zip at {}. Exception is "{}"'.format(zip_url, e), file=sys.stderr)
-        exit(1)
+        return
 
     # Extract zip
     try:
@@ -43,26 +42,13 @@ def download_zip(subdir, zip_url):
         z.extractall(path=subdir)
     except Exception as e:
         print('Unable to extract zip from {}. Exception is "{}"'.format(zip_url, e), file=sys.stderr)
-        exit(1)
+        return
 
 
 def main():
-    arg_parser = argparse.ArgumentParser(description='Script to fetch Redfish tools and build test framework tree')
-    arg_parser.add_argument('-d', '--directory', help='target directory to populate with tests')
-    args = arg_parser.parse_args()
-
-    # TODO: Only support cwd as target?
-    if args.directory is None:
-        target_dir = os.getcwd()
-    else:
-        target_dir = args.directory
-        target_dir = os.path.abspath(target_dir)
-        try:
-            if not os.path.isdir(target_dir):
-                os.mkdir(target_dir)
-        except OSError as e:
-            print("Error creating target directory {}, error: {}".format(target_dir, e), file=sys.stderr)
-            exit(1)
+    arg_parser = argparse.ArgumentParser(
+        description='Fetch Redfish tools and build test framework tree in current working directory')
+    arg_parser.parse_args()
 
     download_list = [
         ['Schema-Validation', 'https://github.com/DMTF/Redfish-Service-Validator/archive/master.zip'],


### PR DESCRIPTION
Fetch the zip files for these tests:
- Redfish-Service-Validator
- Redfish-Reference-Checker
- Redfish-Mockup-Creator
- Redfish-Interop-Validator
- Redfish-Usecase-Checkers

Extract them into expected test framework directory tree.