### PR TITLE
Change file names in example report listings to match current convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ Example directory tree after test run:
 │   ├── root_schema_validation
 │   │   ├── RedfishServiceValidator.py
 │   │   ├── output-2017-06-29T173926Z
-│   │   │   ├── ComplianceHtmlLog_06_29_2017_123941.html
-│   │   │   ├── ComplianceLog_06_29_2017_123941.txt
+│   │   │   ├── ConformanceHtmlLog_06_29_2017_123941.html
+│   │   │   ├── ConformanceLog_06_29_2017_123941.txt
 │   │   │   ├── stderr.log
 │   │   │   └── stdout.log
 │   │   ├── test_conf.json

--- a/RedfishTestFrameworkDesign.md
+++ b/RedfishTestFrameworkDesign.md
@@ -232,7 +232,7 @@ test_framework
 ├── schema_validation_suite
 │   ├── root_schema_validation
 │   │   ├── output-2017-05-18T171529Z
-│   │   │   ├── ComplianceHtmlLog_05_18_2017_171529.html
+│   │   │   ├── ConformanceHtmlLog_05_18_2017_171529.html
 │   │   │   ├── results.json
 │   │   │   ├── stderr.log
 │   │   │   └── stdout.log
@@ -240,7 +240,7 @@ test_framework
 │   │   └── test_conf.json
 │   ├── service_schema_validation
 │   │   ├── output-2017-05-18T171529Z
-│   │   │   ├── ComplianceHtmlLog_05_18_2017_171529.html
+│   │   │   ├── ConformanceHtmlLog_05_18_2017_171529.html
 │   │   │   ├── results.json
 │   │   │   ├── stderr.log
 │   │   │   └── stdout.log


### PR DESCRIPTION
The README.md and RedfishTestFrameworkDesign.md files show example service validator report file names like "ComplianceHtmlLog_06_29_2017_123941.html". These are now named like "ConformanceHtmlLog*.html". Updated the examples to reflect the current naming.

Fixes #5 