### PR TITLE
Eliminate OSError in log output for tests that do not create results.json

### DIFF
--- a/test_framework.py
+++ b/test_framework.py
@@ -537,10 +537,15 @@ class TestCase(object):
                     pass
                 # Read the results.json file if available
                 try:
-                    with open(os.path.join(self.output_dir, self.results_filename)) as results_file:
-                        self.results = json.load(results_file)
+                    results_filename = os.path.join(self.output_dir, self.results_filename)
+                    if os.path.isfile(results_filename):
+                        with open(results_filename) as results_file:
+                            self.results = json.load(results_file)
+                    else:
+                        # Not all tests create results.json; just log debug msg
+                        logging.debug("No 'results.json' file found for test '{}'".format(self.name))
                 except OSError as e:
-                    logging.warning("OSError opening JSON results from file {} in directory {}, error: {}"
+                    logging.error("OSError opening JSON results from file {} in directory {}, error: {}"
                                     .format(self.results_filename, self.output_dir, e))
                 except ValueError as e:
                     logging.error("ValueError loading JSON results from file {} in directory {}, error: {}"


### PR DESCRIPTION
Several of the DMTF test tools do not produce a `results.json` file. When run via the Test-Framework, those tests cause the Test-Framework to emit a warning message that looks like an error:


> Running tests... 
> ----------------------------------------------------------------------
>  test_Other_Tests_Redfish_Mockup_Creator_master (__main__.RedfishTestCase) ... WARNING:root:OSError opening JSON results from file results.json in directory /Users/bdodd/Development/DMTF/test-framework-sandbox/Other-Tests/Redfish-Mockup-Creator-master/output-2019-02-21T212011Z, error: [Errno 2] No such file or directory: '/Users/bdodd/Development/DMTF/test-framework-sandbox/Other-Tests/Redfish-Mockup-Creator-master/output-2019-02-21T212011Z/results.json'
> OK (2.154077)s
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0:00:02
> 
> OK

To fix, I updated the code to not emit this warning when the results.json file does not exist.

The log output now will look like this:

> Running tests... 
> ----------------------------------------------------------------------
>  test_Other_Tests_Redfish_Mockup_Creator_master (__main__.RedfishTestCase) ... OK (2.159666)s
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0:00:02
> 
> OK

Fixes #8 